### PR TITLE
fix: add maintainer file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,30 @@
+# Maintainers
+
+| Maintainer        | GitHub ID       | Company Affiliation |
+| ----------------- | --------------- | ------------------- |
+| Maaike van Leuken | maaikevanleuken | TNO                 |
+| Samuel Rinnetmäki | samuelmr        | Findynet            |
+| Mirko Mollik      | cre8            | Fraunhofer FIT      |
+
+## 1. What Does Being a Maintainer Entail
+
+- Reviewing code contributions.
+- Managing issues and bugs.
+- Maintaining documentation.
+- Communicating with the community.
+- Managing version control.
+- Participating in project decisions.
+- Building and sustaining a contributor community.
+
+## 2. How to Become a Maintainer
+
+Before being considered as a maintainer, contributors should meet the following requirements:
+
+- A history of substantial and consistent contributions to the project.
+- A deep understanding of the project's goals, codebase, and best practices.
+- Active involvement in the community, including helping others and engaging in discussions.
+- Ultimately, the maintainers decide who will become the new maintainer through a majority vote.
+
+## 3. How Maintainers are Removed or Moved to Emeritus Status
+
+- Inactivity or consensus decision can lead to removal.


### PR DESCRIPTION
I used the maintainer file from the sd-jwt-js group and limited it to the required information.

This will give the openwallet repo maintainers a better overview over the active contributors.

@ryjones do you need extra information to know about required privileges? If so, what would be a good approach to document this?