### PR TITLE
Optimize filter

### DIFF
--- a/viewer/src/app/wallets-list/wallets-list.component.html
+++ b/viewer/src/app/wallets-list/wallets-list.component.html
@@ -12,7 +12,13 @@
     </div>
   </div>
   <section class="container">
-    <table mat-table [dataSource]="dataSource" matSort>
+    <table
+      mat-table
+      [dataSource]="dataSource"
+      matSort
+      matSortActive="name"
+      matSortDirection="asc"
+    >
       <ng-container matColumnDef="name" [sticky]="true">
         <th
           mat-header-cell


### PR DESCRIPTION
closes #54 #52 

It updates the logic how fields are compared. When sorting for ascending or descending, non filled out fields will be placed always at the end. This should trigger the providers to fill out the fields even when they need to enter a `false` value.