### PR TITLE
Add operatorModel (who operates the wallet or agent)

### DIFF
--- a/schemas/wallet.json
+++ b/schemas/wallet.json
@@ -57,7 +57,7 @@
     },
     "operatorModel": {
       "type": "array",
-      "description": "Who operates the agent: a person, another agent, or nothing (it runs by itself)",
+      "description": "Modes of operation this entry supports, as a capability of the wallet or agent (an entry may support more than one, hence an array). The three values sit on one axis, degree of human involvement at the moment of operation: user-operated (a person drives each action), agent-operable (an agent may act, with a human remaining the accountable real-time context), autonomous (an agent acts with no human involvement at that moment). This describes what the entry is designed to support, not what happened in a specific transaction; see the IETF operator-of-record claim (opr, draft-aravind-oauth-operator-of-record) for the per-event marker.",
       "items": {
         "type": "string",
         "enum": ["user-operated", "agent-operable", "autonomous"]

--- a/schemas/wallet.json
+++ b/schemas/wallet.json
@@ -55,6 +55,14 @@
         "enum": ["holder", "issuer", "verifier"]
       }
     },
+    "operatorModel": {
+      "type": "array",
+      "description": "Who operates the agent: a person, another agent, or nothing (it runs by itself)",
+      "items": {
+        "type": "string",
+        "enum": ["user-operated", "agent-operable", "autonomous"]
+      }
+    },
     "executionEnvironment":  {
       "type": "string",
       "description": "Execution environment of an agent is the place where the agent is intended to be run",

--- a/viewer/src/app/wallets/types.ts
+++ b/viewer/src/app/wallets/types.ts
@@ -4,6 +4,8 @@ export type Capability = 'holder' | 'issuer' | 'verifier';
 
 export type WalletType = 'cloud' | 'edge';
 
+export type OperatorModel = 'user-operated' | 'agent-operable' | 'autonomous';
+
 export interface Wallet {
   // unique identifier based on the filename
   id: string;
@@ -27,6 +29,8 @@ export interface Wallet {
   license?: string;
   // is the wallet capable of multiple roles
   capability?: Capability[];
+  // who operates it: a person per action, an API caller, or an autonomous process
+  operatorModel?: OperatorModel[];
   // it is a cloud or mobile wallet
   executionEnvironment?: WalletType;
   // am I able to export my data from the wallet/agent and import them into another device/system

--- a/viewer/src/app/wallets/wallets-add/wallets-add.component.html
+++ b/viewer/src/app/wallets/wallets-add/wallets-add.component.html
@@ -94,6 +94,15 @@
         <mat-hint>{{ walletsService.getTooltip('capability') }}</mat-hint>
       </mat-form-field>
       <mat-form-field>
+        <mat-label>Operator model</mat-label>
+        <mat-select formControlName="operatorModel" multiple>
+          <mat-option value="user-operated">User-operated</mat-option>
+          <mat-option value="agent-operable">Agent-operable</mat-option>
+          <mat-option value="autonomous">Autonomous</mat-option>
+        </mat-select>
+        <mat-hint>{{ walletsService.getTooltip('operatorModel') }}</mat-hint>
+      </mat-form-field>
+      <mat-form-field>
         <mat-label>Web site URL</mat-label>
         <input matInput placeholder="https://..." formControlName="urlWebsite" />
         <mat-hint>{{ walletsService.getTooltip('urlWebsite') }}</mat-hint>

--- a/viewer/src/app/wallets/wallets-add/wallets-add.component.ts
+++ b/viewer/src/app/wallets/wallets-add/wallets-add.component.ts
@@ -44,6 +44,7 @@ export class WalletsAddComponent implements OnInit {
     this.values = await this.walletsService.getDefinitions();
     this.form = new FormGroup({
       capability: new FormControl([], [Validators.required]),
+      operatorModel: new FormControl([]),
       type: new FormControl(''),
       name: new FormControl('', [Validators.required]),
       logo: new FormControl(''),

--- a/viewer/src/app/wallets/wallets-list-filter/wallets-list-filter.component.html
+++ b/viewer/src/app/wallets/wallets-list-filter/wallets-list-filter.component.html
@@ -35,6 +35,15 @@
         <mat-hint>{{ walletsService.getTooltip('capability') }}</mat-hint>
       </mat-form-field>
       <mat-form-field>
+        <mat-label>Operator model</mat-label>
+        <mat-select multiple formControlName="operatorModel">
+          <mat-option value="user-operated">User-operated</mat-option>
+          <mat-option value="agent-operable">Agent-operable</mat-option>
+          <mat-option value="autonomous">Autonomous</mat-option>
+        </mat-select>
+        <mat-hint>{{ walletsService.getTooltip('operatorModel') }}</mat-hint>
+      </mat-form-field>
+      <mat-form-field>
         <mat-label>Portability</mat-label>
         <mat-select formControlName="portability">
           <mat-option value=""></mat-option>

--- a/viewer/src/app/wallets/wallets-list-filter/wallets-list-filter.component.ts
+++ b/viewer/src/app/wallets/wallets-list-filter/wallets-list-filter.component.ts
@@ -14,6 +14,7 @@ export interface WalletFilter {
   type?: 'cloud' | 'edge';
   openSource?: 'true' | 'false';
   capability?: ('holder' | 'issuer' | 'verifier')[];
+  operatorModel?: ('user-operated' | 'agent-operable' | 'autonomous')[];
   portability?: 'true' | 'false';
   credentialFormats?: string[];
   credentialProfiles?: string[];
@@ -53,6 +54,7 @@ export class WalletsListFilterComponent implements OnInit {
       type: new FormControl(),
       openSource: new FormControl(),
       capability: new FormControl(),
+      operatorModel: new FormControl(),
       portability: new FormControl(),
     });
     this.walletsService.resources.forEach(resource =>

--- a/viewer/src/app/wallets/wallets-list/wallets-list.component.html
+++ b/viewer/src/app/wallets/wallets-list/wallets-list.component.html
@@ -134,6 +134,29 @@
           </div>
         </td>
       </ng-container>
+      <ng-container matColumnDef="operatorModel">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header
+          [matTooltip]="walletsService.getTooltip('operatorModel')"
+        >
+          Operator model
+        </th>
+        <td mat-cell *matCellDef="let element">
+          <div fxLayout="row" fxLayoutGap="8px">
+            @if (element.operatorModel?.includes('user-operated')) {
+              <span>User-operated</span>
+            }
+            @if (element.operatorModel?.includes('agent-operable')) {
+              <span>Agent-operable</span>
+            }
+            @if (element.operatorModel?.includes('autonomous')) {
+              <span>Autonomous</span>
+            }
+          </div>
+        </td>
+      </ng-container>
       <ng-container matColumnDef="executionEnvironment">
         <th
           mat-header-cell

--- a/viewer/src/app/wallets/wallets-list/wallets-list.component.ts
+++ b/viewer/src/app/wallets/wallets-list/wallets-list.component.ts
@@ -36,6 +36,7 @@ type Colums =
   | 'openSource'
   | 'license'
   | 'capability'
+  | 'operatorModel'
   | 'portability'
   | 'linkToApp'
   | 'dependencies'
@@ -84,6 +85,7 @@ export class WalletsListComponent implements OnInit, AfterViewInit {
     'openSource',
     'license',
     'capability',
+    'operatorModel',
     'portability',
     'linkToApp',
     'dependencies',
@@ -139,6 +141,7 @@ export class WalletsListComponent implements OnInit, AfterViewInit {
         case 'company':
           return (item[property as keyof Wallet] as string) ?? '\ufff0';
         case 'capability':
+        case 'operatorModel':
           return (item[property as keyof Wallet] as string[])?.join(', ') ?? '\ufff0';
         case 'linkToApp':
           return item.urlGooglePlayStore ?? item.urlAppStore ?? '\ufff0';
@@ -245,6 +248,13 @@ export class WalletsListComponent implements OnInit, AfterViewInit {
           wallet =>
             wallet.capability &&
             this.filter!.capability?.every(cap => wallet.capability?.includes(cap))
+        );
+      }
+      if (this.filter.operatorModel && this.filter.operatorModel.length > 0) {
+        values = values.filter(
+          wallet =>
+            wallet.operatorModel &&
+            this.filter!.operatorModel?.every(model => wallet.operatorModel?.includes(model))
         );
       }
       if (this.filter.portability) {

--- a/viewer/src/app/wallets/wallets-show/wallets-show.component.html
+++ b/viewer/src/app/wallets/wallets-show/wallets-show.component.html
@@ -71,6 +71,10 @@
           <div matListItemTitle><b>Capabilities</b></div>
           <span matListItemLine>{{ wallet.capability?.join(', ') }}</span>
         </mat-list-item>
+        <mat-list-item [matTooltip]="walletsService.getTooltip('operatorModel')">
+          <div matListItemTitle><b>Operator model</b></div>
+          <span matListItemLine>{{ wallet.operatorModel?.join(', ') || 'unknown' }}</span>
+        </mat-list-item>
         <mat-list-item [matTooltip]="walletsService.getTooltip('portability')">
           <div matListItemTitle><b>Portability</b></div>
           <span matListItemLine>{{ wallet.portability ?? 'unknown' }}</span>


### PR DESCRIPTION
The field from #166.

Samuel: I went with agent-operable after all. You used it yourself and it keeps the parallel with the other two values, where api-operable named an interface rather than an operator. Nothing is marked autonomous, since none of the current entries would be. And it is an array like capability, as you said.

Mirko: the PR you offered to review. I can do the group description in the same one if you want.

Schema, table column, filter, detail view, add form.

I have not touched any wallet entry. My first attempt filled 73 of them in from what they already declare, then I read it back and it was wrong in both directions: a headless SDK came out user-operated because its urlWebApp points at a docs site, a phone app came out agent-operable because its executionEnvironment says cloud, and Entra and Paradym lost user-operated only because they leave urlWebApp empty. It was also a function of three columns that are already in the file, dressed up as a new fact. This is a vendor-declared dataset, so the values belong to whoever owns each entry.

Build and prettier pass.

Same distinction one layer down, in a draft I posted to the IETF this week: https://datatracker.ietf.org/doc/draft-aravind-oauth-operator-of-record/ marks whether a human or an agent operated a presentation. Worth keeping the words the same if you agree.
